### PR TITLE
feature: add LogAf method to Event to support asynchronous handling in Handler

### DIFF
--- a/event.go
+++ b/event.go
@@ -40,7 +40,7 @@ func newEvent(logger *Logger, level Level) *Event {
 	r.tags = nil
 	r.kvs = nil
 	r.msg = ""
-	r.args = r.args[:0]
+	r.args = nil
 	r.e = nil
 	r.extra = nil
 
@@ -162,6 +162,10 @@ func (e *Event) GetStack() string {
 
 func (e *Event) GetMsg() string {
 	return e.msg
+}
+
+func (e *Event) GetArgs() []interface{} {
+	return e.args
 }
 
 func (e *Event) GetExtra() interface{} {

--- a/event.go
+++ b/event.go
@@ -16,6 +16,7 @@ type Event struct {
 	tags  map[interface{}]interface{}
 	kvs   map[interface{}]interface{}
 	msg   string
+	args  []interface{}
 	e     error
 	extra interface{}
 
@@ -39,6 +40,7 @@ func newEvent(logger *Logger, level Level) *Event {
 	r.tags = nil
 	r.kvs = nil
 	r.msg = ""
+	r.args = r.args[:0]
 	r.e = nil
 	r.extra = nil
 
@@ -110,7 +112,7 @@ func (e *Event) Log() {
 		return
 	}
 
-	e.log("", 2)
+	e.log("", nil, 2)
 }
 
 func (e *Event) Logf(msg string, args ...interface{}) {
@@ -119,10 +121,19 @@ func (e *Event) Logf(msg string, args ...interface{}) {
 	}
 
 	if len(args) > 0 {
-		e.log(fmt.Sprintf(msg, args...), 2)
+		e.log(fmt.Sprintf(msg, args...), nil, 2)
 	} else {
-		e.log(msg, 2)
+		e.log(msg, nil, 2)
 	}
+}
+
+// LogAf support asynchronous fmt.Sprintf in Handler
+func (e *Event) LogAf(msg string, args ...interface{}) {
+	if e == nil {
+		return
+	}
+
+	e.log(msg, args, 2)
 }
 
 func (e *Event) GetLogger() *Logger {
@@ -171,6 +182,7 @@ func (e *Event) Clone() *Event {
 	r.tags = e.tags
 	r.kvs = e.kvs
 	r.msg = e.msg
+	r.args = e.args
 	r.e = e.e
 	r.extra = e.extra
 
@@ -185,9 +197,10 @@ func (e *Event) Put() {
 	_eventPool.Put(e)
 }
 
-func (e *Event) log(msg string, skip int) {
+func (e *Event) log(msg string, args []interface{}, skip int) {
 	e.time = time.Now()
 	e.msg = msg
+	e.args = args
 
 	if e.logger.logCaller(e.level) {
 		frame, ok := e.getCallerFrame(skip)

--- a/event_test.go
+++ b/event_test.go
@@ -37,6 +37,7 @@ func TestEventWithNilLogger(t *testing.T) {
 
 	assert.Equal(t, 1, e.GetExtra())
 	assert.Equal(t, "", e.GetMsg())
+	assert.Equal(t, 0, len(e.GetArgs()))
 	assert.Equal(t, "error", e.GetError().Error())
 
 	assert.Equal(t, "v", e.GetTags()["t"])

--- a/event_test.go
+++ b/event_test.go
@@ -13,6 +13,8 @@ func TestNilEvent(t *testing.T) {
 	assert.NotPanics(t, func() {
 		e.Tag("t", "v").Attach(nil).Log()
 		e.Kv("k", "v").E(nil).Logf("")
+		e.Kv("k", "v").E(nil).LogAf("%d,%d,%d\n", 1, 2, 3)
+		e.Kv("k", "v").E(nil).LogAf("", 1, 2, 3)
 	})
 }
 
@@ -57,6 +59,7 @@ func TestEventWithCaller(t *testing.T) {
 	assert.Equal(t, l, e.GetLogger())
 
 	e.Log()
+	e.LogAf("stderr: %d, %d, %d", 1, 2, 3)
 
 	assert.True(t, e.GetCaller().GetOK())
 	assert.True(t, e.GetCaller().GetPC() > 0)
@@ -69,7 +72,7 @@ func TestEventWithGetCallerError(t *testing.T) {
 	l.EnableCaller(INFO)
 	e := newEvent(l, INFO)
 
-	e.log("", 7000000)
+	e.log("", nil, 7000000)
 
 	assert.False(t, e.caller.ok)
 	assert.True(t, e.caller.pc == 0)

--- a/handler/formatter.go
+++ b/handler/formatter.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"path"
 	"strconv"
 	"strings"
@@ -31,7 +32,13 @@ func JsonFormatter(e *logging.Event) ([]byte, error) {
 		"func": e.GetCaller().GetFunc(),
 		"line": e.GetCaller().GetLine(),
 	}
-	m["msg"] = e.GetMsg()
+	msg := e.GetMsg()
+	args := e.GetArgs()
+	if len(args) > 0 {
+		m["msg"] = fmt.Sprintf(msg, args...)
+	} else {
+		m["msg"] = msg
+	}
 	m["stack"] = e.GetStack()
 	m["extra"] = e.GetExtra()
 
@@ -102,7 +109,13 @@ func StdFormatter(e *logging.Event) ([]byte, error) {
 	buf.WriteString(" ")
 
 	buf.WriteString(Cyan)
-	buf.WriteString(e.GetMsg())
+	msg := e.GetMsg()
+	args := e.GetArgs()
+	if len(args) > 0 {
+		buf.WriteString(fmt.Sprintf(msg, args...))
+	} else {
+		buf.WriteString(msg)
+	}
 	buf.WriteString(Reset)
 
 	if len(e.GetStack()) > 0 {

--- a/handler/ring_test.go
+++ b/handler/ring_test.go
@@ -27,7 +27,7 @@ func BenchmarkRingBufferHandler(b *testing.B) {
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
-			logging.Info().Logf("buf stdout test")
+			logging.Info().LogAf("buf stdout test: %d, %d, %d", 1, 2, 3)
 		}
 	})
 }


### PR DESCRIPTION
For the reason that fmt.Sprintf costs so much time, a more efficient way is to do fmt.Sprintf asynchronously.
But, obviously, the user should know that the arguments of LogAf may change before it's handled.